### PR TITLE
Fix kgPanels:OnInitialize()

### DIFF
--- a/kgPanels.lua
+++ b/kgPanels.lua
@@ -437,7 +437,7 @@ local launcher
 function kgPanels:OnInitialize()
 	self.db = LibStub("AceDB-3.0"):New("kgPanelsDB", dbDefaults, "Default")
 	self:UpgradeDB()
-	if not IsClassic then
+	if not IsClassic() then
 		local LibDualSpec = LibStub('LibDualSpec-1.0',true)
 		if LibDualSpec then
 			LibDualSpec:EnhanceDatabase(self.db, "kgPanels")


### PR DESCRIPTION
Commit 91ff84ee9a02f181e395e1a1d2c52902adfa3d6e introduced a bug causing kgpanels to not correctly initialize on WoW Retail.
In opposition to [kgPanelsConfig\kgPanelsConfig.lua](https://github.com/Stanzilla/kgPanels/blob/master/kgPanelsConfig/kgPanelsConfig.lua#L604) the function was evaluated instead of the true/false return.
This commit fix this bug and permit KgPanels to work on Retail's version

Typical InGame StackTrace :
```
3x kgPanelsConfig\kgPanelsConfig-1.23.lua:607: Usage: LibDualSpec:EnhanceOptions(optionTable, target): EnhanceDatabase should be called before EnhanceOptions(optionTable, target).
[C]: in function `error'
...Ons\Bazooka\libs\LibDualSpec-1.0\LibDualSpec-1.0-17.lua:348: in function `EnhanceOptions'
kgPanelsConfig\kgPanelsConfig-1.23.lua:607: in function <kgPanelsConfig\kgPanelsConfig.lua:596>
[C]: ?
...ceAdiBags\libs\AceAddon-3.0\AceAddon-3.0-12.lua:70: in function <...ceAdiBags\libs\AceAddon-3.0\AceAddon-3.0.lua:65>
...ceAdiBags\libs\AceAddon-3.0\AceAddon-3.0-12.lua:498: in function `InitializeAddon'
...ceAdiBags\libs\AceAddon-3.0\AceAddon-3.0-12.lua:613: in function <...ceAdiBags\libs\AceAddon-3.0\AceAddon-3.0.lua:605>
[C]: in function `LoadAddOn'
kgPanels\kgPanels-1.23.lua:634: in function `?'
...ddOns\AdiBags\libs\AceConsole-3.0\AceConsole-3.0-7.lua:94: in function `?'
FrameXML\ChatFrame.lua:4836: in function <FrameXML\ChatFrame.lua:4783>
[C]: in function `ChatEdit_ParseText'
FrameXML\ChatFrame.lua:4497: in function <FrameXML\ChatFrame.lua:4496>
[C]: in function `ChatEdit_SendText'
FrameXML\ChatFrame.lua:4533: in function `ChatEdit_OnEnterPressed'
[string "*:OnEnterPressed"]:1: in function <[string "*:OnEnterPressed"]:1>

3x kgPanelsConfig\ArtHelper.lua:173: attempt to index field 'artLibrary' (a nil value)
kgPanelsConfig\ArtHelper.lua:173: in function `CreateArtMenu'
kgPanelsConfig\ArtHelper.lua:13: in function `InitArt'
kgPanelsConfig\kgPanelsConfig-1.23.lua:637: in function <kgPanelsConfig\kgPanelsConfig.lua:635>
[C]: ?
...ceAdiBags\libs\AceAddon-3.0\AceAddon-3.0-12.lua:70: in function <...ceAdiBags\libs\AceAddon-3.0\AceAddon-3.0.lua:65>
...ceAdiBags\libs\AceAddon-3.0\AceAddon-3.0-12.lua:527: in function `EnableAddon'
...ceAdiBags\libs\AceAddon-3.0\AceAddon-3.0-12.lua:620: in function <...ceAdiBags\libs\AceAddon-3.0\AceAddon-3.0.lua:605>
[C]: in function `LoadAddOn'
kgPanels\kgPanels-1.23.lua:634: in function `?'
...ddOns\AdiBags\libs\AceConsole-3.0\AceConsole-3.0-7.lua:94: in function `?'
FrameXML\ChatFrame.lua:4836: in function <FrameXML\ChatFrame.lua:4783>
[C]: in function `ChatEdit_ParseText'
FrameXML\ChatFrame.lua:4497: in function <FrameXML\ChatFrame.lua:4496>
[C]: in function `ChatEdit_SendText'
FrameXML\ChatFrame.lua:4533: in function `ChatEdit_OnEnterPressed'
[string "*:OnEnterPressed"]:1: in function <[string "*:OnEnterPressed"]:1>

2x kgPanels\kgPanels-1.23.lua:462: kgPanelsConfig isn't registed with AceConfigRegistry, unable to open config
[C]: ?
...nfig-3.0\AceConfigDialog-3.0\AceConfigDialog-3.0-78.lua:1861: in function `Open'
kgPanels\kgPanels-1.23.lua:462: in function `OnClick'
Bazooka\Bazooka-v2.9.3.lua:1418: in function <Bazooka\Bazooka.lua:1415>

Locals:
(*temporary) = "kgPanelsConfig isn't registed with AceConfigRegistry, unable to open config"
```