### PR TITLE
fix pre-processor logic in embeds.xml

### DIFF
--- a/embeds.xml
+++ b/embeds.xml
@@ -7,7 +7,7 @@
 	<Include file="Libs\AceConsole-3.0\AceConsole-3.0.xml"/>
 	<Include file="Libs\LibSharedMedia-3.0\lib.xml"/>
 	<Script file="Libs\LibBackdrop-1.0\LibBackdrop-1.0.lua"/>
-	<!--@non-retail@
+	<!--@retail@-->
 	<Script file="Libs\LibDualSpec-1.0\LibDualSpec-1.0.lua"/>
-	@end-non-retail@-->
+	<!--@end-retail@-->
 </Ui>


### PR DESCRIPTION
The release.sh script was not removing LibDualSpec for Classic builds. Switching to using the @retail@ keyword fixes the problem, and LibDualSpec will be commented out for Classic releases.